### PR TITLE
move default sky/edit texture config

### DIFF
--- a/textures.cfg
+++ b/textures.cfg
@@ -1,0 +1,20 @@
+setshader stdworld
+texture 0 "textures/sky.png"
+texture 0 "textures/edit/edit_1.png" 0 0 0 2
+texture 0 "textures/edit/edit_2.png" 0 0 0 2
+texture 0 "textures/edit/edit_3.png" 0 0 0 2
+texture 0 "textures/edit/edit_4.png" 0 0 0 2
+texture 0 "textures/edit/edit_5.png" 0 0 0 2
+texture 0 "textures/edit/edit_6.png" 0 0 0 2
+
+texture 0 "textures/default.png"
+texture 0 "textures/default.png"
+texpalette 1 0
+texture 0 "textures/default.png"
+texpalette 1 1
+texture 0 "textures/default.png"
+texpalette 1 2
+texture 0 "textures/default.png"
+texpalette 0 1
+texture 0 "textures/default.png"
+texpalette 0 3


### PR DESCRIPTION
Additional PR for base/ https://github.com/redeclipse/base/pull/1053

Changes proposed in this request:
- move sky/edit texture slots into textures/textures.cfg
- moving these slots to textures/textures.cfg resolves the problem

Problem:
When running `texturereset` and then `texturerehash` these textures fail to load correctly, resulting in this (edit tex missing, and slot 0 uses the wrong texture): 
![2020-05-07-124536_1920x1080_scrot](https://user-images.githubusercontent.com/1535179/81292324-4c085d00-9063-11ea-94c7-10a5e9679dcf.png)
